### PR TITLE
Initialize scheduler project structure

### DIFF
--- a/data/patients.json
+++ b/data/patients.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "patient_01",
+    "name": "Lucas Smith",
+    "age": 5,
+    "school_status": "preschool",
+    "available_days": ["Mon", "Wed"],
+    "available_hours": ["14:00-17:00"],
+    "parent_available_hours": ["13:30-17:30"],
+    "sibling_ids": ["patient_02"],
+    "grouping_type": "same_time",
+    "preferred_specialties": ["speech delay"]
+  },
+  {
+    "id": "patient_02",
+    "name": "Sophia Smith",
+    "age": 7,
+    "school_status": "elementary",
+    "available_days": ["Mon", "Wed"],
+    "available_hours": ["14:00-17:00"],
+    "parent_available_hours": ["13:30-17:30"],
+    "sibling_ids": ["patient_01"],
+    "grouping_type": "same_time",
+    "preferred_specialties": ["speech delay"]
+  },
+  {
+    "id": "patient_03",
+    "name": "Noah Brown",
+    "age": 6,
+    "school_status": "preschool",
+    "available_days": ["Tue", "Thu"],
+    "available_hours": ["10:00-12:00"],
+    "parent_available_hours": ["09:30-12:30"],
+    "sibling_ids": [],
+    "grouping_type": "none",
+    "preferred_specialties": ["fluency"]
+  }
+]

--- a/data/schedule_output.json
+++ b/data/schedule_output.json
@@ -1,0 +1,10 @@
+{
+  "therapist_1": {
+    "name": "Emily Chen",
+    "schedule": {}
+  },
+  "therapist_2": {
+    "name": "Michael Lee",
+    "schedule": {}
+  }
+}

--- a/data/therapists.json
+++ b/data/therapists.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "therapist_1",
+    "name": "Emily Chen",
+    "available_days": ["Mon", "Wed", "Fri"],
+    "available_hours": ["08:00-12:00", "13:00-17:00"],
+    "specialties": ["speech delay", "apraxia"]
+  },
+  {
+    "id": "therapist_2",
+    "name": "Michael Lee",
+    "available_days": ["Tue", "Thu"],
+    "available_hours": ["09:00-12:00", "13:00-16:00"],
+    "specialties": ["fluency", "articulation"]
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ortools

--- a/scheduler/constraint_solver.py
+++ b/scheduler/constraint_solver.py
@@ -1,0 +1,20 @@
+"""Placeholder constraint solver for the speech therapy scheduler."""
+
+
+def solve_schedule(therapists, patients):
+    """Return an empty schedule structure for each therapist.
+
+    Args:
+        therapists (list[dict]): Therapist data.
+        patients (list[dict]): Patient data.
+
+    Returns:
+        dict: Mapping therapist_id -> {"name": str, "schedule": dict}
+    """
+    schedule = {}
+    for therapist in therapists:
+        schedule[therapist["id"]] = {
+            "name": therapist["name"],
+            "schedule": {}
+        }
+    return schedule

--- a/scheduler/run_scheduler.py
+++ b/scheduler/run_scheduler.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from constraint_solver import solve_schedule
+from utils import load_json, save_json
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+
+
+def main():
+    therapists = load_json(DATA_DIR / "therapists.json")
+    patients = load_json(DATA_DIR / "patients.json")
+    schedule = solve_schedule(therapists, patients)
+    save_json(schedule, DATA_DIR / "schedule_output.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scheduler/utils.py
+++ b/scheduler/utils.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+
+def parse_time_range(time_range: str):
+    """Split a time range string like '08:00-12:00' into start and end."""
+    start, end = time_range.split("-")
+    return start.strip(), end.strip()
+
+
+def load_json(path: Path):
+    """Load JSON data from a file path."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(data, path: Path):
+    """Save JSON data to a file path."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/simulate_cancellation.py
+++ b/simulate_cancellation.py
@@ -1,0 +1,10 @@
+"""Placeholder script to simulate session cancellations."""
+
+
+def simulate_cancellation():
+    """Placeholder function for future cancellation simulation."""
+    print("Cancellation simulation not implemented.")
+
+
+if __name__ == "__main__":
+    simulate_cancellation()

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Speech Therapy Schedule</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Therapist Schedule</h1>
+  <select id="therapist-select"></select>
+  <div id="schedule"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/ui/script.js
+++ b/ui/script.js
@@ -1,0 +1,39 @@
+async function loadSchedule() {
+  const response = await fetch('../data/schedule_output.json');
+  const data = await response.json();
+  const select = document.getElementById('therapist-select');
+  const scheduleDiv = document.getElementById('schedule');
+
+  for (const id in data) {
+    const option = document.createElement('option');
+    option.value = id;
+    option.textContent = data[id].name;
+    select.appendChild(option);
+  }
+
+  function render() {
+    const therapistId = select.value;
+    scheduleDiv.innerHTML = '';
+    const therapist = data[therapistId];
+    if (!therapist) return;
+    for (const day in therapist.schedule) {
+      const dayDiv = document.createElement('div');
+      dayDiv.className = 'day';
+      const heading = document.createElement('h2');
+      heading.textContent = day;
+      dayDiv.appendChild(heading);
+      therapist.schedule[day].forEach(slot => {
+        const slotDiv = document.createElement('div');
+        slotDiv.className = 'time-slot';
+        slotDiv.textContent = `${slot.time} - ${slot.patient_name}`;
+        dayDiv.appendChild(slotDiv);
+      });
+      scheduleDiv.appendChild(dayDiv);
+    }
+  }
+
+  select.addEventListener('change', render);
+  render();
+}
+
+loadSchedule();

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1,0 +1,14 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+.day {
+  margin-bottom: 20px;
+}
+
+.time-slot {
+  border: 1px solid #ccc;
+  padding: 4px;
+  margin: 2px 0;
+}


### PR DESCRIPTION
## Summary
- add sample data files and an empty schedule output
- scaffold scheduler package with placeholder solver and utilities
- create basic UI and simulation script for testing

## Testing
- `python -m py_compile scheduler/*.py simulate_cancellation.py`
- `python scheduler/run_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_688d9b9ca21083268a132f5abd7e3931